### PR TITLE
feat(workflow.py): Finish `calendar_data_parser_step`

### DIFF
--- a/backend/src/enums.py
+++ b/backend/src/enums.py
@@ -5,6 +5,8 @@ class ProgressEventType(str, Enum):
     INIT = "init"
     CALENDAR_DATA_RETRIEVAL = "calendar_data_retrieval"
     CALENDAR_DATA_PARSER = "calendar_data_parser"
+    CALENDAR_EVENT = "calendar_event"
+    RESEARCH = "research"
     PROCESSING = "processing"
     FORMATTING = "formatting"
     COMPLETED = "completed"

--- a/backend/src/events.py
+++ b/backend/src/events.py
@@ -40,8 +40,15 @@ class FormatEvent(Event):
 
 
 class ResearchEvent(Event):
-    attendees: List[str] = Field(
+    calendar_events: Optional[List[str]] = Field(
+        default_factory=list,
+        description="List of calendar events retrieved from the calendar data",
+    )
+
+    attendees: Optional[List[str]] = Field(
         default_factory=list,
         description="List of attendees for the meeting",
     )
-    company: str = Field(description="Company name for the meeting")
+    company: Optional[str] = Field(
+        default=None, description="Company name for the meeting"
+    )

--- a/backend/src/models/attendee.py
+++ b/backend/src/models/attendee.py
@@ -9,9 +9,9 @@ class Attendee(BaseModel):
     name: Optional[str] = Field(
         description="Name of the attendee",
     )
-    position: Optional[str] = Field(
+    role: Optional[str] = Field(
         default=None,
-        description="Position of the attendee in the company",
+        description="Role of the attendee in the company",
     )
     info: Optional[str] = Field(
         default=None,

--- a/backend/src/prompts.py
+++ b/backend/src/prompts.py
@@ -40,7 +40,7 @@ Desired Pydantic schema
             {
                 "email": string,
                 "name": string | null,
-                "position": string | null,
+                "role": string | null,
                 "info": string | null
             },
         …
@@ -72,7 +72,7 @@ For each such attendee:
 
 "name" → the attendee’s display name (or null if missing).
 
-"position" → map from jobTitle in the input JSON (or null if that key is absent).
+"role" → the attendee’s role in the company (or null if missing).
 
 "info" → map from any notes or comment field in the input (or null if no additional data).
 
@@ -102,7 +102,7 @@ FORMAT_RESPONSE_PROMPT_TEMPLATE = """You are a meeting preparation assistant. Gi
         - **Background:** [any relevant background information about the meeting or the relationship with the company, if available]
 
         - ### Company Information
-        - [key facts about the company, such as industry, size, recent news, etc., from the research results]
+        - [key facts about the company, such as industry, main product, size, recent news, etc., from the research results]
 
         - ### Attendees
         - #### [Attendee Name]
@@ -126,11 +126,11 @@ FORMAT_RESPONSE_PROMPT_TEMPLATE = """You are a meeting preparation assistant. Gi
 """
 
 
-REACT_AGENT_USER_PROMPT_TEMPLATE = """Your goal is to help me prepare for an upcoming meeting by gathering information about the attendees and the company we are meeting with.
+REACT_AGENT_USER_PROMPT_TEMPLATE = """Your goal is to help me prepare for an upcoming meetings by gathering information about the attendees and the company we are meeting with.
 
-            You will be provided with the following meeting information:
+            You will be provided with the following meetings information:
 
-            {{meeting_info}}
+            {{meetings_info}}
 
             Please perform the following tasks, using available tools {{tools}}:
 
@@ -152,4 +152,7 @@ REACT_AGENT_USER_PROMPT_TEMPLATE = """Your goal is to help me prepare for an upc
             4. If you are unable to find the profile of any attendee or information about the company, clearly state which information was not found and suggest possible reasons or alternative approaches.
 
             Do not include anything else in the output besides the requested summaries and links.
+            
+            Do this for each meeting in the provided meetings information.
+            {{meetings_info}}
             """


### PR DESCRIPTION
-**enums.py**- `CALENDAR_EVENT` and `RESEARCH` have been added to `ProgressEventType`

-**events.py**- A new filed `calendar_events` has been added to `ResearchEvent`. Now if we have `calendar_events` it means that a user wants to get meetings data from their calendar otherwise `attendees` and `company` were manually provided from the frontend

-**prompts.py**- `REACT_AGENT_USER_PROMPT_TEMPLATE` has been adjusted to account for multiple meetings. `FORMAT_RESPONSE_PROMPT_TEMPLATE` has been adjusted and `main product` has been added. In `EXTRACT_CALENDAR_DATA_PROMPT_TEMPLATE` `position` has been changed into `role` to align with the `Attendee` class from `attendee.py`

-**attendee.py**- `position` field has been changed to `role`